### PR TITLE
Add hint for installing fzf on Windows and Linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ This extension depends on [fzf](https://github.com/junegunn/fzf#readme) as a fuz
 brew install fzf
 ```
 
+See the fzf documentation for details on installing on [Windows](https://github.com/junegunn/fzf#windows) and [Linux](https://github.com/junegunn/fzf#using-linux-package-managers)
+
 ## Usage
 ```
 gh branch


### PR DESCRIPTION
As silly as it sounds, I initially overlooked the extension some time ago, because I wasn't familiar with `fzf`,  and didn't know that I could also install it easily on Windows 😅 

So, add a tiny hint & links to relevant sections in `fzf`'s documentation for users on those platforms.